### PR TITLE
chore: Remove unused Scala cross-version configuration.

### DIFF
--- a/bleep.yaml
+++ b/bleep.yaml
@@ -4,9 +4,6 @@ jvm:
   name: temurin:17
 projects:
   dialogue-state-core:
-    cross:
-      scala2: {}
-      scala3: {}
     dependencies: dev.zio::zio-http:3.0.1
     extends: template-cross-all
     folder: ./core
@@ -20,9 +17,6 @@ projects:
     dependsOn: dialogue-state-core
     extends: template-cross-all
   twilio:
-    cross:
-      scala2: {}
-      scala3: {}
     dependencies:
     - com.lihaoyi::scalatags:0.13.1
     - com.twilio.sdk:twilio:10.6.10


### PR DESCRIPTION
Simplified the build configuration by removing empty `scala2` and `scala3` cross-version entries.
