### PR TITLE
Refactor Record and Gather into abstract classes

### DIFF
--- a/core/src/scala/io/github/nafg/dialoguestate/Menu.scala
+++ b/core/src/scala/io/github/nafg/dialoguestate/Menu.scala
@@ -1,27 +1,32 @@
 package io.github.nafg.dialoguestate
 
+import io.github.nafg.dialoguestate.CallTree.Callback
+
 import zio.ZIO
 import zio.prelude.NonEmptyList
 
-//noinspection ScalaUnusedSymbol
-object Menu {
-  def apply[A: ToText](title: CallTree.NoContinuation, choices: NonEmptyList[A], preposition: String = "for")(
-    handler: A => CallTree.Callback
-  ): CallTree.Gather = {
-    val withNums         = LazyList.from(1).map(_.toString).zip(choices.toCons)
-    lazy val withNumsMap = withNums.toMap
+abstract class Menu[A: ToText](title: CallTree.NoContinuation, choices: NonEmptyList[A], preposition: String = "for")
+    extends CallTree.Gather(actionOnEmptyResult = true, finishOnKey = None) {
 
-    val prompts = title +: withNums.flatMap { case (n, d) =>
-      Seq(CallTree.Say(s"Press $n $preposition"), CallTree.Say(d), CallTree.Pause())
-    }
+  private val withNums = LazyList.from(1).map(_.toString).zip(choices.toCons)
 
-    CallTree.Gather(finishOnKey = None, actionOnEmptyResult = true)(prompts*) {
-      case ""             => ZIO.fail(Left("Please make a selection"))
-      case withNumsMap(a) => handler(a)
-      case _              => ZIO.fail(Left("That is not one of the choices"))
-    }
+  override def message =
+    title &:
+      withNums.foldLeft[CallTree.NoContinuation](CallTree.empty) { case (agg, (n, d)) =>
+        agg &: CallTree.Say(s"Press $n $preposition") &: CallTree.Say(d) &: CallTree.Pause()
+      }
+
+  private lazy val WithNumsMap = withNums.toMap
+
+  override def handle = {
+    case ""             => ZIO.fail(Left("Please make a selection"))
+    case WithNumsMap(a) => handleChoice(a)
+    case _              => ZIO.fail(Left("That is not one of the choices"))
   }
 
-  def yesNo(title: CallTree.NoContinuation)(handler: Boolean => CallTree.Callback): CallTree.Gather =
-    Menu[Boolean](title, NonEmptyList(true, false))(handler)
+  def handleChoice: A => Callback
+}
+//noinspection ScalaUnusedSymbol
+object Menu {
+  abstract class YesNo(title: CallTree.NoContinuation) extends Menu[Boolean](title, NonEmptyList(true, false))
 }


### PR DESCRIPTION
### Refactor Overview
  - Converted `Record` and `Gather` classes to abstract classes.
  - Added abstract `handle` method within each class for consistent implementation requirements in derived classes.

### Purpose of Change
  Hopefully this brings us closer to being able to store the calls state externally. Subclasses can be case classes with
  derived codecs; what still needs to be solved is how to ensure the CallStateServer knows the decoder to use.