### PR TITLE
Set rewrite rules for Scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,6 +9,9 @@ align {
   preset = most
   allowOverflow = false
 }
+
+rewrite.rules = [RedundantBraces, RedundantParens]
+
 fileOverride {
   "glob:**/scripts/src/scala/**" {
      runner.dialect = scala3

--- a/core/src/scala/io/github/nafg/dialoguestate/CallStateServer.scala
+++ b/core/src/scala/io/github/nafg/dialoguestate/CallStateServer.scala
@@ -123,7 +123,7 @@ abstract class CallStateServer(
 
   private def callsEndpoint(callsStates: CallsStates): Routes[Any, Nothing] =
     Routes(RoutePattern.GET / rootPath.encode / "calls" -> handler {
-      callsStates.states.get.map { map => Response.text(map.mkString("\n")) }
+      callsStates.states.get.map(map => Response.text(map.mkString("\n")))
     })
 
   // noinspection ScalaUnusedSymbol


### PR DESCRIPTION
Added `RedundantBraces` and `RedundantParens` to Scalafmt configuration, ensuring cleaner and more consistent code formatting.
