### PR TITLE
feat!: enhance recording functionality with transcription support

### DIFF
--- a/core-test/src/scala/io/github/nafg/dialoguestate/test/ComplexIvrExampleTest.scala
+++ b/core-test/src/scala/io/github/nafg/dialoguestate/test/ComplexIvrExampleTest.scala
@@ -274,7 +274,7 @@ object ComplexIvrExampleTest extends ZIOSpecDefault {
 
   private val leaveMessageTree: CallTree = {
     val record = new CallTree.Record {
-      override def handle(result: RecordingResult): CallTree.Callback =
+      override def handle(recordingUrl: URL, terminator: Option[RecordingResult.Terminator]): CallTree.Callback =
         ZIO.succeed(
           CallTree
             .Say("Thank you for your message. A customer service representative will contact you within 24 hours.") &:
@@ -366,7 +366,7 @@ object ComplexIvrExampleTest extends ZIOSpecDefault {
         _      <- tester.expect("Customer Service Menu")
         _      <- tester.sendDigits("3")
         _      <- tester.expect("Please leave your message")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/message/123"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/message/123")
         _      <- tester.expect("Thank you for your message")
         _      <- tester.expect("A customer service representative will contact you")
         _      <- tester.sendDigits("0")

--- a/core-test/src/scala/io/github/nafg/dialoguestate/test/ProductInfoExampleTest.scala
+++ b/core-test/src/scala/io/github/nafg/dialoguestate/test/ProductInfoExampleTest.scala
@@ -171,7 +171,7 @@ object ProductInfoExampleTest extends ZIOSpecDefault {
 
   private val problemReportingTree: CallTree = {
     object record extends CallTree.Record {
-      override def handle(result: RecordingResult): CallTree.Callback = {
+      override def handle(recordingUrl: URL, terminator: Option[RecordingResult.Terminator]): CallTree.Callback = {
         object responseTree extends CallTree.Gather(numDigits = Some(1), timeout = 8) {
           override def message: CallTree.NoContinuation = CallTree.Say("")
 
@@ -324,7 +324,7 @@ object ProductInfoExampleTest extends ZIOSpecDefault {
         _      <- tester.sendDigits("3")
         _      <- tester.expect("We're sorry you're experiencing an issue")
         _      <- tester.expect("Please describe the problem")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/problem/123"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/problem/123")
         _      <- tester.expect("Thank you for reporting the issue")
         _      <- tester.expect("Press 1 to return to the main menu")
         _      <- tester.sendDigits("1")

--- a/core-test/src/scala/io/github/nafg/dialoguestate/test/SimpleMenuExampleTest.scala
+++ b/core-test/src/scala/io/github/nafg/dialoguestate/test/SimpleMenuExampleTest.scala
@@ -31,9 +31,9 @@ object SimpleMenuExampleTest extends ZIOSpecDefault {
 
   private val recordMessageTree: CallTree = {
     val record = new CallTree.Record {
-      override def handle(result: RecordingResult): CallTree.Callback =
+      override def handle(recordingUrl: URL, terminator: Option[RecordingResult.Terminator]): CallTree.Callback =
         ZIO.succeed(
-          CallTree.Say(s"Thank you for your message. It was recorded at ${result.url.encode}.") &:
+          CallTree.Say(s"Thank you for your message. It was recorded at ${recordingUrl.encode}.") &:
             CallTree.Say("A representative will listen to your message and get back to you within 24 hours.")
         )
     }
@@ -77,7 +77,7 @@ object SimpleMenuExampleTest extends ZIOSpecDefault {
         _      <- tester.expect("Welcome to the test menu")
         _      <- tester.sendDigits("3")
         _      <- tester.expect("Please record your message")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/123"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/123")
         _      <- tester.expect("Thank you for your message")
         _      <- tester.expect("A representative will listen to your message")
       } yield assertCompletes

--- a/core-test/src/scala/io/github/nafg/dialoguestate/test/SurveyExampleTest.scala
+++ b/core-test/src/scala/io/github/nafg/dialoguestate/test/SurveyExampleTest.scala
@@ -12,7 +12,8 @@ object SurveyExampleTest extends ZIOSpecDefault {
   private object surveyIntro extends CallTree.Gather(numDigits = Some(1), timeout = 10) {
     override def message: CallTree.NoContinuation =
       CallTree.Say(
-        "Thank you for participating in our customer satisfaction survey. This will take approximately 2 minutes to complete. " +
+        "Thank you for participating in our customer satisfaction survey. " +
+          "This will take approximately 2 minutes to complete. " +
           "Press 1 to continue or 2 to opt out."
       )
 
@@ -139,7 +140,7 @@ object SurveyExampleTest extends ZIOSpecDefault {
 
   private def improvementSuggestionRecording(aspect: String): CallTree = {
     object record extends CallTree.Record {
-      override def handle(result: RecordingResult): CallTree.Callback =
+      override def handle(recordingUrl: URL, terminator: Option[RecordingResult.Terminator]): CallTree.Callback =
         ZIO.succeed(
           CallTree.Say(s"Thank you for your suggestions on how we can improve our $aspect.") &:
             recommendationQuestion
@@ -201,7 +202,7 @@ object SurveyExampleTest extends ZIOSpecDefault {
 
   private val testimonialRecording: CallTree = {
     object record extends CallTree.Record {
-      override def handle(result: RecordingResult): CallTree.Callback =
+      override def handle(recordingUrl: URL, terminator: Option[RecordingResult.Terminator]): CallTree.Callback =
         ZIO.succeed(
           CallTree.Say("Thank you for your testimonial! We really appreciate your support.") &:
             additionalCommentsQuestion
@@ -227,7 +228,7 @@ object SurveyExampleTest extends ZIOSpecDefault {
 
   private val additionalCommentsRecording: CallTree = {
     object record extends CallTree.Record {
-      override def handle(result: RecordingResult): CallTree.Callback =
+      override def handle(recordingUrl: URL, terminator: Option[RecordingResult.Terminator]): CallTree.Callback =
         ZIO.succeed(surveyConclusion)
     }
 
@@ -259,7 +260,7 @@ object SurveyExampleTest extends ZIOSpecDefault {
         _      <- tester.expect("Would you be willing to provide a testimonial")
         _      <- tester.sendDigits("1")
         _      <- tester.expect("Please record your testimonial")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/testimonial/123"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/testimonial/123")
         _      <- tester.expect("Thank you for your testimonial")
         _      <- tester.expect("Would you like to provide any additional comments")
         _      <- tester.sendDigits("2")
@@ -279,7 +280,7 @@ object SurveyExampleTest extends ZIOSpecDefault {
         _      <- tester.sendDigits("3")
         _      <- tester.expect("We're sorry about the customer service issues")
         _      <- tester.expect("Please tell us how we could improve")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/improvement/456"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/improvement/456")
         _      <- tester.expect("Thank you for your suggestions")
         _      <- tester.expect("On a scale of 0 to 10, how likely are you to recommend")
         _      <- tester.sendDigits("3")
@@ -287,7 +288,7 @@ object SurveyExampleTest extends ZIOSpecDefault {
         _      <- tester.expect("Would you like to provide any additional comments")
         _      <- tester.sendDigits("1")
         _      <- tester.expect("Please record your additional comments")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/comments/789"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/comments/789")
         _      <- tester.expect("Thank you for completing our customer satisfaction survey")
       } yield assertCompletes
     },
@@ -312,7 +313,7 @@ object SurveyExampleTest extends ZIOSpecDefault {
         _      <- tester.sendDigits("2")
         _      <- tester.expect("Thank you for your feedback")
         _      <- tester.expect("Please tell us how we could improve")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/neutral/123"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/neutral/123")
         _      <- tester.expect("Thank you for your suggestions")
         _      <- tester.expect("On a scale of 0 to 10, how likely are you to recommend")
         _      <- tester.sendDigits("7")

--- a/core-test/src/scala/io/github/nafg/dialoguestate/test/TestMenuExampleTest.scala
+++ b/core-test/src/scala/io/github/nafg/dialoguestate/test/TestMenuExampleTest.scala
@@ -23,8 +23,8 @@ object TestMenuExampleTest extends ZIOSpecDefault {
 
   private val recordMessageTree: CallTree = {
     val record = new CallTree.Record {
-      override def handle(result: RecordingResult): CallTree.Callback =
-        ZIO.succeed(CallTree.Say(s"Thank you for your message. It was recorded at ${result.url.encode}."))
+      override def handle(recordingUrl: URL, terminator: Option[RecordingResult.Terminator]): CallTree.Callback =
+        ZIO.succeed(CallTree.Say(s"Thank you for your message. It was recorded at ${recordingUrl.encode}."))
     }
 
     CallTree.Say("Please record your message after the beep.") &: record
@@ -116,7 +116,7 @@ object TestMenuExampleTest extends ZIOSpecDefault {
         tester <- CallTreeTester(menuTree)
         _      <- tester.sendDigits("3")
         _      <- tester.expect("Please record your message")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/123"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/123")
         _      <- tester.expect("Thank you for your message")
       } yield assertCompletes
     },

--- a/core-test/src/scala/io/github/nafg/dialoguestate/test/TranscriptionExampleTest.scala
+++ b/core-test/src/scala/io/github/nafg/dialoguestate/test/TranscriptionExampleTest.scala
@@ -1,0 +1,105 @@
+package io.github.nafg.dialoguestate.test
+
+import io.github.nafg.dialoguestate.*
+
+import zio.*
+import zio.http.*
+import zio.test.*
+
+/** Test demonstrating CallTree transcription functionality
+  */
+object TranscriptionExampleTest extends ZIOSpecDefault {
+  object TranscriptionTree extends CallTree.Gather(numDigits = Some(1), timeout = 10) {
+    override def message: CallTree.NoContinuation =
+      CallTree.Say(
+        "Welcome to the transcription demo. Press 1 to record with transcription, or 2 to record without transcription."
+      )
+
+    override def handle: String => CallTree.Callback = {
+      case "1" => ZIO.succeed(transcribedRecording)
+      case "2" => ZIO.succeed(standardRecording)
+      case _   => ZIO.succeed(CallTree.Say("Invalid selection. Please try again.") &: this)
+    }
+  }
+
+  private val transcribedRecording: CallTree = {
+    object record extends CallTree.Record.Transcribed() {
+      override def handle(
+        recordingUrl: URL,
+        transcriptionText: Option[String],
+        terminator: Option[RecordingResult.Terminator]
+      ): CallTree.Callback =
+        ZIO.succeed {
+          val transcriptionInfo = transcriptionText match {
+            case Some(transcription) => s"Your message was transcribed as: '$transcription'. "
+            case None                => "Your message was recorded, but transcription is not available."
+          }
+
+          CallTree.Say(s"Thank you for your message. It was recorded at ${recordingUrl.encode}.") &:
+            CallTree.Say(transcriptionInfo) &:
+            confirmationMenu
+        }
+    }
+
+    CallTree.Say("Please speak your message after the tone. Press # when you are finished.") &: record
+  }
+
+  private val standardRecording: CallTree = {
+    object record extends CallTree.Record() {
+      override def handle(recordingUrl: URL, terminator: Option[RecordingResult.Terminator]): CallTree.Callback =
+        ZIO.succeed(
+          CallTree.Say(s"Thank you for your message. It was recorded at ${recordingUrl.encode}.") &:
+            CallTree.Say("Transcription was not enabled for this recording.") &:
+            confirmationMenu
+        )
+    }
+
+    CallTree.Say("Please speak your message after the tone. Press # when you are finished.") &: record
+  }
+
+  private object confirmationMenu extends CallTree.Gather(numDigits = Some(1), timeout = 10) {
+    override def message: CallTree.NoContinuation =
+      CallTree.Say("Press 1 to record another message or 2 to finish.")
+
+    override def handle: String => CallTree.Callback = {
+      case "1" => ZIO.succeed(CallTree.Say("Let's record another message.") &: TranscriptionTree)
+      case "2" => ZIO.succeed(CallTree.Say("Thank you for using our transcription demo. Goodbye."))
+      case _   => ZIO.succeed(CallTree.Say("Invalid selection. Please try again.") &: this)
+    }
+  }
+
+  override def spec: Spec[TestEnvironment, Any] = suite("Transcription Test")(
+    test("can record with transcription") {
+      for {
+        tester <- CallTreeTester(TranscriptionTree)
+        _      <- tester.expect("Welcome to the transcription demo")
+        _      <- tester.sendDigits("1")
+        _      <- tester.expect("Please speak your message after the tone")
+        _      <- tester.sendTranscribedRecording(
+                    url"https://example.com/recordings/123",
+                    Some("This is a test of the transcription feature")
+                  )
+        _      <- tester.expect("Thank you for your message")
+        _      <- tester.expect("Your message was transcribed as")
+        _      <- tester.expect("This is a test of the transcription feature")
+        _      <- tester.expect("Press 1 to record another message")
+        _      <- tester.sendDigits("2") // Finish
+        _      <- tester.expect("Thank you for using our transcription demo")
+      } yield assertCompletes
+    },
+    test("can record without transcription") {
+      for {
+        tester <- CallTreeTester(TranscriptionTree)
+        _      <- tester.expect("Welcome to the transcription demo")
+        _      <- tester.sendDigits("2")
+        _      <- tester.expect("Please speak your message after the tone")
+        _      <- tester.sendRecording(url"https://example.com/recordings/456")
+        _      <- tester.expect("Thank you for your message")
+        _      <- tester.expect("Transcription was not enabled for this recording")
+        _      <- tester.expect("Press 1 to record another message")
+        _      <- tester.sendDigits("2") // Finish
+        _      <- tester.expect("Thank you for using our transcription demo")
+      } yield assertCompletes
+    }
+  ) @@ TestAspect.diagnose(10.seconds)
+}

--- a/core-test/src/scala/io/github/nafg/dialoguestate/test/VoicemailExampleTest.scala
+++ b/core-test/src/scala/io/github/nafg/dialoguestate/test/VoicemailExampleTest.scala
@@ -12,7 +12,8 @@ object VoicemailExampleTest extends ZIOSpecDefault {
   object VoicemailTree extends CallTree.Gather(numDigits = Some(1), timeout = 10) {
     override def message: CallTree.NoContinuation =
       CallTree.Say(
-        "Welcome to the voicemail system. Press 1 to leave a message, 2 to leave an urgent message, or 3 to leave feedback."
+        "Welcome to the voicemail system. " +
+          "Press 1 to leave a message, 2 to leave an urgent message, or 3 to leave feedback."
       )
 
     override def handle: String => CallTree.Callback = {
@@ -25,9 +26,9 @@ object VoicemailExampleTest extends ZIOSpecDefault {
 
   private val standardRecording: CallTree = {
     object record extends CallTree.Record {
-      override def handle(result: RecordingResult): CallTree.Callback =
+      override def handle(recordingUrl: URL, terminator: Option[RecordingResult.Terminator]): CallTree.Callback =
         ZIO.succeed(
-          CallTree.Say(s"Thank you for your message. It was recorded at ${result.url.encode}.") &:
+          CallTree.Say(s"Thank you for your message. It was recorded at ${recordingUrl.encode}.") &:
             CallTree.Say("Your message will be delivered to the recipient.") &:
             confirmationMenu
         )
@@ -38,9 +39,9 @@ object VoicemailExampleTest extends ZIOSpecDefault {
 
   private val urgentRecording: CallTree = {
     object record extends CallTree.Record {
-      override def handle(result: RecordingResult): CallTree.Callback =
+      override def handle(recordingUrl: URL, terminator: Option[RecordingResult.Terminator]): CallTree.Callback =
         ZIO.succeed(
-          CallTree.Say(s"Thank you for your urgent message. It was recorded at ${result.url.encode}.") &:
+          CallTree.Say(s"Thank you for your urgent message. It was recorded at ${recordingUrl.encode}.") &:
             CallTree.Say("Your message will be marked as urgent and delivered immediately.") &:
             confirmationMenu
         )
@@ -51,9 +52,9 @@ object VoicemailExampleTest extends ZIOSpecDefault {
 
   private val feedbackRecording: CallTree = {
     object record extends CallTree.Record {
-      override def handle(result: RecordingResult): CallTree.Callback =
+      override def handle(recordingUrl: URL, terminator: Option[RecordingResult.Terminator]): CallTree.Callback =
         ZIO.succeed(
-          CallTree.Say(s"Thank you for your feedback. It was recorded at ${result.url.encode}.") &:
+          CallTree.Say(s"Thank you for your feedback. It was recorded at ${recordingUrl.encode}.") &:
             CallTree.Say("Your feedback will be reviewed by our team.") &:
             confirmationMenu
         )
@@ -81,7 +82,7 @@ object VoicemailExampleTest extends ZIOSpecDefault {
         _      <- tester.expect("Welcome to the voicemail system")
         _      <- tester.sendDigits("1")
         _      <- tester.expect("Please leave your message after the tone")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/standard/123"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/standard/123")
         _      <- tester.expect("Thank you for your message")
         _      <- tester.expect("Your message will be delivered")
         _      <- tester.expect("Press 1 to listen")
@@ -95,7 +96,7 @@ object VoicemailExampleTest extends ZIOSpecDefault {
         _      <- tester.expect("Welcome to the voicemail system")
         _      <- tester.sendDigits("2")
         _      <- tester.expect("Please leave your urgent message")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/urgent/456"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/urgent/456")
         _      <- tester.expect("Thank you for your urgent message")
         _      <- tester.expect("Your message will be marked as urgent")
         _      <- tester.expect("Press 1 to listen")
@@ -109,7 +110,7 @@ object VoicemailExampleTest extends ZIOSpecDefault {
         _      <- tester.expect("Welcome to the voicemail system")
         _      <- tester.sendDigits("3")
         _      <- tester.expect("Please leave your feedback")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/feedback/789"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/feedback/789")
         _      <- tester.expect("Thank you for your feedback")
         _      <- tester.expect("Your feedback will be reviewed")
         _      <- tester.expect("Press 1 to listen")
@@ -123,15 +124,15 @@ object VoicemailExampleTest extends ZIOSpecDefault {
         _      <- tester.expect("Welcome to the voicemail system")
         _      <- tester.sendDigits("1")
         _      <- tester.expect("Please leave your message")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/123"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/123")
         _      <- tester.expect("Thank you for your message")
         _      <- tester.expect("Press 1 to listen")
         _      <- tester.sendDigits("2")                           // Re-record
         _      <- tester.expect("Let's try again")
-        _      <- tester.expect("Welcome to the voicemail system") // Back to main menu
+        _      <- tester.expect("Welcome to the voicemail system") // Back to the main menu
         _      <- tester.sendDigits("1")                           // Choose standard recording again
         _      <- tester.expect("Please leave your message")
-        _      <- tester.sendRecording(RecordingResult(url"https://example.com/recordings/456"))
+        _      <- tester.sendRecording(url"https://example.com/recordings/456")
         _      <- tester.expect("Thank you for your message")
         _      <- tester.sendDigits("3")                           // Finish
         _      <- tester.expect("Thank you for using our voicemail system")

--- a/core/src/scala/io/github/nafg/dialoguestate/CallState.scala
+++ b/core/src/scala/io/github/nafg/dialoguestate/CallState.scala
@@ -1,8 +1,17 @@
 package io.github.nafg.dialoguestate
 
-sealed trait CallState
-object CallState {
-  case class Ready(callTree: CallTree)                  extends CallState
-  case class AwaitingDigits(gather: CallTree.Gather)    extends CallState
-  case class AwaitingRecording(record: CallTree.Record) extends CallState
+import zio.Promise
+
+sealed trait CallState {
+  def callTree: CallTree
+}
+object CallState       {
+  case class Ready(callTree: CallTree)                 extends CallState
+  case class AwaitingDigits(callTree: CallTree.Gather) extends CallState
+  case class AwaitingRecording(callTree: CallTree.Record, data: Promise[Nothing, RecordingResult.Data.Untranscribed])
+      extends CallState
+  case class AwaitingTranscribedRecording(
+    callTree: CallTree.Record.Transcribed,
+    data: Promise[Nothing, RecordingResult.Data.Transcribed]
+  ) extends CallState
 }

--- a/core/src/scala/io/github/nafg/dialoguestate/RecordingResult.scala
+++ b/core/src/scala/io/github/nafg/dialoguestate/RecordingResult.scala
@@ -2,11 +2,20 @@ package io.github.nafg.dialoguestate
 
 import zio.http.URL
 
-case class RecordingResult(url: URL, terminator: Option[RecordingResult.Terminator] = None)
+case class RecordingResult[A <: RecordingResult.Data](data: A, terminator: Option[RecordingResult.Terminator] = None)
 object RecordingResult {
   sealed trait Terminator
   object Terminator {
     case object Hangup         extends Terminator
     case class Key(dtmf: DTMF) extends Terminator
+  }
+
+  type Transcribed   = RecordingResult[Data.Transcribed]
+  type Untranscribed = RecordingResult[Data.Untranscribed]
+
+  sealed trait Data
+  object Data {
+    case class Untranscribed(recordingUrl: URL)                                  extends Data
+    case class Transcribed(recordingUrl: URL, transcriptionText: Option[String]) extends Data
   }
 }

--- a/telnyx-test/src/scala/io/github/nafg/dialoguestate/telnyx/TagsTest.scala
+++ b/telnyx-test/src/scala/io/github/nafg/dialoguestate/telnyx/TagsTest.scala
@@ -47,16 +47,30 @@ object TagsTest extends ZIOSpecDefault {
           """<Redirect>https://example.com/base</Redirect>"""
       )
     },
-    test("Record") {
+    test("Record without transcription") {
       val node = Node.Record(
         maxLength = Some(60),
         finishOnKey = Set(DTMF('#')),
-        recordingStatusCallback = url"https://example.com/recording-status"
+        recordingStatusCallback = url"https://example.com/recording-status",
+        transcribeCallback = None
       )
       assertTrue(
         render(node) ==
-          """<Record maxLength="60" finishOnKey="#" recordingStatusCallback="https://example.com/recording-status"""" +
-          """ action="https://example.com/base"></Record>"""
+          """<Record maxLength="60" finishOnKey="#" recordingStatusCallback="https://example.com/recording-status" """ +
+          """action="https://example.com/base"></Record>"""
+      )
+    },
+    test("Record with transcription") {
+      val node = Node.Record(
+        maxLength = Some(60),
+        finishOnKey = Set(DTMF('#')),
+        recordingStatusCallback = url"https://example.com/recording-status",
+        transcribeCallback = Some(url"https://example.com/transcribe-callback")
+      )
+      assertTrue(
+        render(node) ==
+          """<Record maxLength="60" finishOnKey="#" recordingStatusCallback="https://example.com/recording-status" """ +
+          """action="https://example.com/base"></Record>"""
       )
     }
   )

--- a/telnyx/src/scala/io/github/nafg/dialoguestate/telnyx/Tags.scala
+++ b/telnyx/src/scala/io/github/nafg/dialoguestate/telnyx/Tags.scala
@@ -44,7 +44,7 @@ private object Tags {
         if (actionOnEmptyResult) gatherVerb
         else
           frag(gatherVerb, fromNode(Node.Redirect(baseUrl), baseUrl))
-      case Node.Record(maxLen, finishOn, recordingStatusCB)                =>
+      case Node.Record(finishOn, maxLen, recordingStatusCB, _)             =>
         Record(
           maxLen.map(maxLength := _),
           finishOnKey             := finishOn.mkString,

--- a/twilio-base/src/scala/io/github/nafg/dialoguestate/twilio/base/Node.scala
+++ b/twilio-base/src/scala/io/github/nafg/dialoguestate/twilio/base/Node.scala
@@ -18,5 +18,10 @@ object Node {
     sealed trait Child extends Node
   }
 
-  case class Record(maxLength: Option[Int], finishOnKey: Set[DTMF], recordingStatusCallback: URL) extends Node
+  case class Record(
+    finishOnKey: Set[DTMF],
+    maxLength: Option[Int],
+    recordingStatusCallback: URL,
+    transcribeCallback: Option[URL]
+  ) extends Node
 }

--- a/twilio-test/src/scala/io/github/nafg/dialoguestate/twilio/TagsTest.scala
+++ b/twilio-test/src/scala/io/github/nafg/dialoguestate/twilio/TagsTest.scala
@@ -37,15 +37,30 @@ object TagsTest extends ZIOSpecDefault {
             """<Say voice="man">Press a digit</Say></Gather>""")
       )
     },
-    test("Record") {
+    test("Record without transcription") {
       val node = Node.Record(
         maxLength = Some(60),
         finishOnKey = Set(DTMF('#')),
-        recordingStatusCallback = url"https://example.com/recording-status"
+        recordingStatusCallback = url"https://example.com/recording-status",
+        transcribeCallback = None
       )
       assertTrue(
         render(node) ==
           """<Record maxLength="60" finishOnKey="#" recordingStatusCallback="https://example.com/recording-status">""" +
+          """</Record>"""
+      )
+    },
+    test("Record with transcription") {
+      val node = Node.Record(
+        maxLength = Some(60),
+        finishOnKey = Set(DTMF('#')),
+        recordingStatusCallback = url"https://example.com/recording-status",
+        transcribeCallback = Some(url"https://example.com/transcribe-callback")
+      )
+      assertTrue(
+        render(node) ==
+          """<Record maxLength="60" finishOnKey="#" recordingStatusCallback="https://example.com/recording-status"""" +
+          """ transcribe="true" transcribeCallback="https://example.com/transcribe-callback">""" +
           """</Record>"""
       )
     }


### PR DESCRIPTION
Updated `CallTree.Record` to support transcription in addition to plain recordings.
Adjusted related testing and server logic to handle transcribed recordings comprehensively.

This also addresses the issue that while we wait for the recording status promise to be fulfilled
in order to return a TwiML response, Twilio may time out the request.
Now if 5 seconds go by, we tell Twilio to say "Please wait" and try again.

BREAKING CHANGE: signature of CallTree.Record.handle has changed. RecordingResult is no longer part of the API
