### PR TITLE
fix(CallTree.Gather)!: set default for actionOnEmptyResult to true

### DIFF
--- a/core/src/scala/io/github/nafg/dialoguestate/CallTree.scala
+++ b/core/src/scala/io/github/nafg/dialoguestate/CallTree.scala
@@ -95,7 +95,7 @@ object CallTree {
     *   TwiML instruction.
     */
   abstract class Gather(
-    val actionOnEmptyResult: Boolean = false,
+    val actionOnEmptyResult: Boolean = true,
     val finishOnKey: Option[DTMF] = Some('#'),
     val numDigits: Option[Int] = None,
     val timeout: Int = 5


### PR DESCRIPTION
This behavior usually is what you want
