### PR TITLE
fix(test): update log icon to better represent hearing event

### DIFF
--- a/core/src/scala/io/github/nafg/dialoguestate/test/CallTreeTester.scala
+++ b/core/src/scala/io/github/nafg/dialoguestate/test/CallTreeTester.scala
@@ -272,7 +272,7 @@ object CallTreeTester {
                      case other                                    =>
                        ZIO.fail(UnexpectedStateException(s"to hear '$text'", other))
                    }
-          _     <- ZIO.logInfo(s" ✅ Heard '${highlight(text)}'")
+          _     <- ZIO.logInfo(s" 👂 Heard '${highlight(text)}'")
         } yield res
       } *>
         currentState


### PR DESCRIPTION
Changed the log message icon from a checkmark to an ear emoji in CallTreeTester.scala to more accurately represent the action of hearing text during tests. This improves log clarity and readability by aligning the icon with the event being logged.