### PR TITLE
feat(test): add expectAndSend helper to CallTreeTester

### DIFF
--- a/core/src/scala/io/github/nafg/dialoguestate/test/CallTreeTester.scala
+++ b/core/src/scala/io/github/nafg/dialoguestate/test/CallTreeTester.scala
@@ -276,6 +276,8 @@ object CallTreeTester {
         } yield res
       } *>
         currentState
+
+    def expectAndSend(texts: String*)(digits: String) = expect(texts*) *> sendDigits(digits)
   }
 
   /** Creates a new tester for the given CallTree


### PR DESCRIPTION
Introduced a new helper method `expectAndSend` in CallTreeTester to
combine the common pattern of expecting multiple texts followed by
sending digits. This improves test code readability and reduces
boilerplate when writing tests that involve this sequence of actions.
