### PR TITLE
fix(test): improve MissingExpectedTextException message clarity

### DIFF
--- a/core/src/scala/io/github/nafg/dialoguestate/test/CallTreeTester.scala
+++ b/core/src/scala/io/github/nafg/dialoguestate/test/CallTreeTester.scala
@@ -72,9 +72,13 @@ object CallTreeTester {
         s"Expected ${highlight(expectationDescription)} but got ${highlight(actualState.toString)}"
       )
 
-  case class MissingExpectedTextException(expectedText: String, actualText: Seq[Node])
+  case class MissingExpectedTextException(expectedText: String, actualNodes: Seq[Node])
       extends AssertionError(
-        s"Expected to hear '${highlight(expectedText)}' but got: ${actualText.map("\n • " + _).mkString}"
+        s"Expected to hear '${highlight(expectedText)}' but " +
+          (if (actualNodes.isEmpty)
+             "no nodes remain"
+           else
+             s"got: ${actualNodes.map("\n • " + _).mkString}")
       )
 
   /** Represents a tester for a CallTree program


### PR DESCRIPTION
Refined the exception message in MissingExpectedTextException to handle the case
when no nodes remain. Changed the parameter name from actualText to actualNodes to
better reflect its type (Seq[Node]). This improves error diagnostics by clearly
indicating when the expected text was missing due to an empty node sequence.
