### PR TITLE
feat(menu): introduce Menu.Options trait and improve menu handling

### DIFF
--- a/bleep.yaml
+++ b/bleep.yaml
@@ -4,7 +4,9 @@ jvm:
   name: temurin:17
 projects:
   dialogue-state-core:
-    dependencies: dev.zio::zio-http:3.3.3
+    dependencies:
+    - com.lihaoyi::sourcecode:0.4.2
+    - dev.zio::zio-http:3.3.3
     extends: template-cross-all
     folder: ./core
   dialogue-state-core-test:

--- a/core/src/scala/io/github/nafg/dialoguestate/CallState.scala
+++ b/core/src/scala/io/github/nafg/dialoguestate/CallState.scala
@@ -6,9 +6,9 @@ sealed trait CallState {
   def callTree: CallTree
 }
 object CallState       {
-  case class Ready(callTree: CallTree)                 extends CallState
-  case class AwaitingDigits(callTree: CallTree.Gather) extends CallState
-  case class AwaitingPayment(callTree: CallTree.Pay)   extends CallState
+  case class Ready(callTree: CallTree)                      extends CallState
+  case class AwaitingDigits(callTree: CallTree.Gather.Base) extends CallState
+  case class AwaitingPayment(callTree: CallTree.Pay)        extends CallState
   case class AwaitingRecording(callTree: CallTree.Record, data: Promise[Nothing, RecordingResult.Data.Untranscribed])
       extends CallState
   case class AwaitingTranscribedRecording(

--- a/core/src/scala/io/github/nafg/dialoguestate/CallTree.scala
+++ b/core/src/scala/io/github/nafg/dialoguestate/CallTree.scala
@@ -111,13 +111,21 @@ object CallTree {
     *   TwiML instruction.
     */
   abstract class Gather(
-    val actionOnEmptyResult: Boolean = true,
-    val finishOnKey: Optional[DTMF] = Optional.Present('#'),
-    val numDigits: Optional[Int] = Optional.Absent,
-    val timeout: Int = 5
-  ) extends CallTree.HasContinuation {
-    def message: NoContinuation
-    def handle: String => Callback
+    actionOnEmptyResult: Boolean = true,
+    finishOnKey: Optional[DTMF] = Optional.Present('#'),
+    override val numDigits: Optional[Int] = Optional.Absent,
+    timeout: Int = 5
+  ) extends Gather.Base(actionOnEmptyResult = actionOnEmptyResult, finishOnKey = finishOnKey, timeout = timeout)
+  object Gather {
+    abstract class Base(
+      val actionOnEmptyResult: Boolean = true,
+      val finishOnKey: Optional[DTMF] = Optional.Present('#'),
+      val timeout: Int = 5
+    ) extends CallTree.HasContinuation {
+      def numDigits: Optional[Int] = Optional.Absent
+      def message: NoContinuation
+      def handle: String => Callback
+    }
   }
 
   // noinspection ScalaUnusedSymbol

--- a/core/src/scala/io/github/nafg/dialoguestate/Menu.scala
+++ b/core/src/scala/io/github/nafg/dialoguestate/Menu.scala
@@ -1,36 +1,63 @@
 package io.github.nafg.dialoguestate
 
-import io.github.nafg.dialoguestate.CallTree.Callback
-
 import zio.ZIO
 import zio.prelude.NonEmptyList
 
-abstract class Menu[A: ToText](title: CallTree.NoContinuation, choices: NonEmptyList[A], preposition: String = "for")
-    extends CallTree.Gather(
-      actionOnEmptyResult = true,
-      finishOnKey = None,
-      numDigits = Some((choices.length + 1).toString.length)
-    ) {
-
-  private val withNums = LazyList.from(1).map(_.toString).zip(choices.toCons)
-
-  override def message =
-    title &:
-      withNums.foldLeft[CallTree.NoContinuation](CallTree.empty) { case (agg, (n, d)) =>
-        agg &: CallTree.Say(s"Press $n $preposition") &: CallTree.Say(d) &: CallTree.Pause()
-      }
-
-  private lazy val WithNumsMap = withNums.toMap
-
-  override def handle = {
-    case ""             => ZIO.fail(Left("Please make a selection"))
-    case WithNumsMap(a) => handleChoice(a)
-    case _              => ZIO.fail(Left("That is not one of the choices"))
-  }
-
-  def handleChoice: A => Callback
-}
+abstract class Menu[A: ToText](
+  title: CallTree.NoContinuation,
+  override val choices: NonEmptyList[A],
+  preposition: String = "for"
+) extends Menu.Base[A](title, preposition)
 //noinspection ScalaUnusedSymbol
 object Menu {
   abstract class YesNo(title: CallTree.NoContinuation) extends Menu[Boolean](title, NonEmptyList(true, false))
+
+  abstract class Base[A: ToText](title: CallTree.NoContinuation, preposition: String = "for")
+      extends CallTree.Gather.Base(actionOnEmptyResult = true, finishOnKey = None) {
+    protected def choices: NonEmptyList[A]
+
+    final override def numDigits = Some((choices.length + 1).toString.length)
+
+    private val withNums: LazyList[(String, A)] = LazyList.from(1).map(_.toString).zip(choices.toCons)
+
+    override def message =
+      title &:
+        withNums.foldLeft[CallTree.NoContinuation](CallTree.empty) { case (agg, (n, d)) =>
+          agg &: CallTree.Say(s"Press $n $preposition") &: CallTree.Say(d) &: CallTree.Pause()
+        }
+
+    private lazy val WithNumsMap = withNums.toMap
+
+    final override def handle = {
+      case ""             => ZIO.fail(Left("Please make a selection"))
+      case WithNumsMap(a) => handleChoice(a)
+      case _              => ZIO.fail(Left("That is not one of the choices"))
+    }
+
+    protected def handleChoice: A => CallTree.Callback
+  }
+
+  trait Options extends Enumeration {
+
+    /** Like [[Value]] but uses [[sourcecode.Name]] for the name */
+    protected def sourcecodeNamedValue(implicit name: sourcecode.Name): Value = Value(name.value)
+
+    implicit def toText: ToText[Value] = ToText { value =>
+      value.toString
+    }
+
+    abstract class Menu(title: CallTree.NoContinuation, preposition: String = "for")
+        extends Base[Value](title, preposition) {
+      override protected lazy val choices =
+        NonEmptyList
+          .fromIterableOption(values.filter(handleOption.isDefinedAt(_)): @unchecked)
+          .getOrElse(sys.error(s"No options are handled by $getClass.handleChoice"))
+
+      protected def handleOption: PartialFunction[Value, CallTree.Callback]
+
+      final override protected def handleChoice: Value => CallTree.Callback =
+        handleOption
+          .orElse { case _ => ZIO.fail(Left("That is not one of the choices")) }
+    }
+  }
 }

--- a/twilio-base/src/scala/io/github/nafg/dialoguestate/twilio/base/TwilioBaseCallStateServer.scala
+++ b/twilio-base/src/scala/io/github/nafg/dialoguestate/twilio/base/TwilioBaseCallStateServer.scala
@@ -90,7 +90,7 @@ abstract class TwilioBaseCallStateServer(
   override protected def interpretTree(callTree: CallTree): UIO[Result] =
     callTree match {
       case noCont: CallTree.NoContinuation              => ZIO.succeed(Result(toNodes(noCont)))
-      case gather: CallTree.Gather                      =>
+      case gather: CallTree.Gather.Base                 =>
         val node =
           Node.Gather(
             actionOnEmptyResult = gather.actionOnEmptyResult,


### PR DESCRIPTION
Refactored Menu to add a new Menu.Options trait that provides an enumeration-based
API for defining menu options with sourcecode-based names, improving type safety and
usability. The Menu class now extends a new Menu.Base abstract class that uses
CallTree.Gather.Base, aligning with recent changes to CallTree.Gather hierarchy.

Also updated CallTree.Gather to introduce a Base subclass for better type
separation and refined AwaitingDigits state to use CallTree.Gather.Base.

TestMenuExampleTest was updated to use the new Menu.Options trait and cleaner option
handling with named values instead of string matching. The test code now uses
choose() instead of sendDigits() for clarity.

CallTreeTester was enhanced with a more robust expect implementation that searches
for matching Say nodes and added a choose() helper to select menu options by text.

These changes improve API ergonomics, type safety, and test clarity when working with
menu-driven call trees.
