### PR TITLE
refactor(test): enhance CallTreeTester with callId and logging

### DIFF
--- a/core-test/src/scala/io/github/nafg/dialoguestate/test/SuspendExampleTest.scala
+++ b/core-test/src/scala/io/github/nafg/dialoguestate/test/SuspendExampleTest.scala
@@ -76,9 +76,8 @@ object SuspendExampleTest extends ZIOSpecDefault {
             say"Hello caller from ${info.from} to ${info.to}"
           }
       }
-      val customCallInfo = CallInfo(callId = "test-123", from = "+15551234567", to = "+15559876543")
       for {
-        tester <- CallTreeTester(contextAwareSuspendTree, customCallInfo)
+        tester <- CallTreeTester(contextAwareSuspendTree, from = "+15551234567", to = "+15559876543")
         _      <- tester.expect("Hello caller from +15551234567 to +15559876543")
       } yield assertCompletes
     },


### PR DESCRIPTION
Refactored CallTreeTester to generate a unique callId per instance and include it in
exception messages and log annotations. This improves test diagnostics by associating
errors and logs with specific test call instances. Removed the default CallInfo parameter
and replaced it with explicit from/to parameters, simplifying test usage. Added
callId-based context to all send and expect methods for clearer tracing of test execution
steps. Updated SuspendExampleTest to use the new CallTreeTester API. Overall, these
changes improve observability and maintainability of call tree tests.
