### PR TITLE
feat(CallTree): add traverse helpers for Seq and Option with continuations

### DIFF
--- a/core-test/src/scala/io/github/nafg/dialoguestate/test/TraverseTest.scala
+++ b/core-test/src/scala/io/github/nafg/dialoguestate/test/TraverseTest.scala
@@ -1,0 +1,58 @@
+package io.github.nafg.dialoguestate.test
+
+import io.github.nafg.dialoguestate.*
+import io.github.nafg.dialoguestate.ToSay.interpolator
+
+import zio.*
+import zio.test.*
+
+object TraverseTest extends ZIOSpecDefault {
+  // A simple Gather to exercise the HasContinuation overload
+  private case class EchoGather(label: String) extends CallTree.Gather(numDigits = 1) {
+    override def message: CallTree.NoContinuation    = say"Gather for $label. Press any key."
+    override def handle: String => CallTree.Callback = digits => ZIO.succeed(say"Handled $label with $digits")
+  }
+
+  override def spec: Spec[TestEnvironment, Any] = suite("CallTree.traverse")(
+    test("traverse Seq with NoContinuation") {
+      val tree: CallTree.NoContinuation = CallTree.traverse(Seq(1, 2, 3))(i => say"Item $i")
+      for {
+        tester <- CallTreeTester(tree)
+        _      <- tester.expect("Item 1", "Item 2", "Item 3")
+        _      <- tester.expectEnded
+      } yield assertCompletes
+    },
+    test("traverse Option with NoContinuation - Some") {
+      val tree: CallTree.NoContinuation = CallTree.traverse(Option(42))(i => say"Value $i")
+      for {
+        tester <- CallTreeTester(tree)
+        _      <- tester.expect("Value 42")
+        _      <- tester.expectEnded
+      } yield assertCompletes
+    },
+    test("traverse Option with NoContinuation - None") {
+      val tree: CallTree.NoContinuation = CallTree.traverse(Option.empty[Int])(i => say"Value $i")
+      for {
+        tester <- CallTreeTester(tree)
+        _      <- tester.expectEnded
+      } yield assertCompletes
+    },
+    test("traverse Option with HasContinuation - Some") {
+      val tree: CallTree = CallTree.traverse(Option("X"))(EchoGather(_))
+      for {
+        tester <- CallTreeTester(tree)
+        _      <- tester.expect("Gather for X")
+        _      <- tester.sendDigits("7")
+        _      <- tester.expect("Handled X with 7")
+        _      <- tester.expectEnded
+      } yield assertCompletes
+    },
+    test("traverse Option with HasContinuation - None") {
+      val tree: CallTree = CallTree.traverse(Option.empty[String])(EchoGather(_))
+      for {
+        tester <- CallTreeTester(tree)
+        _      <- tester.expectEnded
+      } yield assertCompletes
+    }
+  )
+}


### PR DESCRIPTION
Refactor CallTree traversal methods to provide unified and flexible APIs for
handling collections and optional values with and without continuations. Added
fromSeq and fromOption methods for NoContinuation and HasContinuation types.
Introduced TraverseOptionPartiallyApplied to support partial application for
Option traversal with both NoContinuation and HasContinuation.

This improves code clarity and usability by consolidating traversal logic and
supporting more concise and expressive construction of CallTree sequences.

Also added comprehensive tests in TraverseTest to verify behavior of traverse
with Seq and Option inputs, covering both continuation cases and empty options.
