### PR TITLE
feat(pay): add maxAttempts and timeout to Pay nodes and CallTree

### DIFF
--- a/core/src/scala/io/github/nafg/dialoguestate/CallTree.scala
+++ b/core/src/scala/io/github/nafg/dialoguestate/CallTree.scala
@@ -100,7 +100,9 @@ object CallTree {
   case class Play(url: URL) extends CallTree.NoContinuation
 
   sealed abstract class Pay(val tokenType: String, val description: String) extends CallTree.HasContinuation {
+    def maxAttempts: Option[Int]                 = None
     def prompts: Map[Pay.Prompt, NoContinuation] = Map.empty
+    def timeout: Option[Int]                     = None
 
     def handle(paymentResult: PaymentResult): Callback
   }

--- a/twilio-base/src/scala/io/github/nafg/dialoguestate/twilio/base/HtmlUi.scala
+++ b/twilio-base/src/scala/io/github/nafg/dialoguestate/twilio/base/HtmlUi.scala
@@ -16,9 +16,9 @@ object HtmlUi {
       yield <.input(^.`type` := "hidden", ^.name := k, ^.value := vv)()
 
   def fromNode(node: Node, info: CallInfo): Frag = node match {
-    case Node.Pause(length)                                 => <.span("-" * length)
-    case Node.Play(url)                                     => <.audio(^.src := url.encode, ^.controls := true)
-    case Node.Pay(paymentConnector, description, tokenType) =>
+    case Node.Pause(length)      => <.span("-" * length)
+    case Node.Play(url)          => <.audio(^.src := url.encode, ^.controls := true)
+    case Node.Pay(_, _, _, _, _) =>
       frag(
         <.form(
           <.input(^.tpe := "hidden", ^.name := "Result", ^.value       := "success"),
@@ -34,8 +34,8 @@ object HtmlUi {
           <.button(^.`type` := "submit")("Submit payment error")
         )
       )
-    case Node.Redirect(url) => <.a(^.href := url.addQueryParams(callParams(info)).encode)("Redirect")
-    case Node.Say(text, voice)                              => <.p(text)
+    case Node.Redirect(url)      => <.a(^.href := url.addQueryParams(callParams(info)).encode)("Redirect")
+    case Node.Say(text, voice)   => <.p(text)
     case gather @ Node.Gather(actionOnEmptyResult, finishOnKey, numDigits, timeout) =>
       def childTags(children: List[Node.Gather.Child]): List[Tag] = children match {
         case Nil                                                                                   => Nil

--- a/twilio-base/src/scala/io/github/nafg/dialoguestate/twilio/base/Node.scala
+++ b/twilio-base/src/scala/io/github/nafg/dialoguestate/twilio/base/Node.scala
@@ -8,7 +8,13 @@ sealed trait Node
 object Node {
   case class Pause(length: Int = 1) extends Node with Gather.Child with Pay.Prompt.Child
   case class Play(url: URL)         extends Node with Gather.Child with Pay.Prompt.Child
-  case class Pay(paymentConnector: Option[String], description: String, tokenType: String)(val children: Pay.Prompt*)
+  case class Pay(
+    description: String,
+    maxAttempts: Option[Int] = None,
+    paymentConnector: Option[String],
+    timeout: Option[Int] = None,
+    tokenType: String
+  )(val children: Pay.Prompt*)
       extends Node
   object Pay {
     case class Prompt(

--- a/twilio/src/scala/io/github/nafg/dialoguestate/twilio/TwilioCallStateServer.scala
+++ b/twilio/src/scala/io/github/nafg/dialoguestate/twilio/TwilioCallStateServer.scala
@@ -22,18 +22,22 @@ class TwilioCallStateServer(
       requestVerificationMiddlewareService = requestVerificationMiddlewareService
     ) {
   override protected def toNode(pay: CallTree.Pay): Node.Pay =
-    Node.Pay(paymentConnector = paymentConnector, description = pay.description, tokenType = pay.tokenType)(
-      pay.prompts.toSeq.map {
-        case (CallTree.Pay.Prompt(_for, cardTypes, attempt, requireMatchingInputs, errorType), children) =>
-          Node.Pay.Prompt(
-            `for` = _for.map(_.value),
-            cardTypes = cardTypes.map(_.value),
-            attempt = attempt,
-            requireMatchingInputs = requireMatchingInputs,
-            errorType = errorType.map(_.value)
-          )(toNodes(children)*)
-      }*
-    )
+    Node.Pay(
+      description = pay.description,
+      maxAttempts = pay.maxAttempts,
+      paymentConnector = paymentConnector,
+      timeout = pay.timeout,
+      tokenType = pay.tokenType
+    )(pay.prompts.toSeq.map {
+      case (CallTree.Pay.Prompt(_for, cardTypes, attempt, requireMatchingInputs, errorType), children) =>
+        Node.Pay.Prompt(
+          `for` = _for.map(_.value),
+          cardTypes = cardTypes.map(_.value),
+          attempt = attempt,
+          requireMatchingInputs = requireMatchingInputs,
+          errorType = errorType.map(_.value)
+        )(toNodes(children)*)
+    }*)
 
   private val expirationFormatter = DateTimeFormatter.ofPattern("MMyy")
 


### PR DESCRIPTION
Introduced optional maxAttempts and timeout fields to the Pay class in CallTree and
Node.Pay to better support payment attempt limits and timeouts. Updated related
HTML rendering and tag generation to include these new attributes. Adjusted
TwilioCallStateServer to propagate these new properties when converting CallTree.Pay
to Node.Pay. This change improves the expressiveness and configurability of payment
flows by allowing control over retry attempts and timeouts.
